### PR TITLE
Feat/handle dashboard db locks

### DIFF
--- a/ampere/common.py
+++ b/ampere/common.py
@@ -143,8 +143,13 @@ def get_model_foreign_key(model: SQLModelMetaclass, fk_name: str) -> Optional[st
             return k
 
 
-def get_db_con(read_only: bool = True) -> DuckDBPyConnection:
-    db_path = Path(__file__).parents[1] / "data" / "ampere.duckdb"
+def get_frontend_db_con(read_only: bool = True) -> DuckDBPyConnection:
+    db_path = Path(__file__).parents[1] / "data" / "frontend.duckdb"
+    return duckdb.connect(str(db_path), read_only=read_only)
+
+
+def get_backend_db_con(read_only: bool = True) -> DuckDBPyConnection:
+    db_path = Path(__file__).parents[1] / "data" / "backend.duckdb"
     return duckdb.connect(str(db_path), read_only=read_only)
 
 

--- a/ampere/create_network_graph.py
+++ b/ampere/create_network_graph.py
@@ -1,0 +1,100 @@
+import pickle
+import random
+from pathlib import Path
+
+import networkx as nx
+
+from ampere.common import get_backend_db_con, timeit
+from ampere.models import Followers, StargazerNetworkRecord
+
+
+def dump_graph_to_pickle(pkl_name: str, graph: nx.Graph):
+    out_dir = Path(__file__).parents[1] / "data" / "viz"
+    out_dir.mkdir(exist_ok=True, parents=True)
+
+    out_path = out_dir / f"{pkl_name}.pkl"
+    with out_path.open("wb") as f:
+        pickle.dump(graph, f)
+
+
+def create_follower_network() -> None:
+    con = get_backend_db_con()
+    followers = (
+        con.sql("select user_id, follower_id from int_internal_followers")
+        .to_df()
+        .to_dict(orient="records")
+    )
+    followers = list(Followers(**record) for record in followers)  # type: ignore
+
+    random.seed(42)
+    added_nodes = []
+    graph = nx.Graph()
+    for record in followers:
+        if record.user_id not in added_nodes:
+            graph.add_node(record.user_id)
+            added_nodes.append(record.user_id)
+
+        if record.follower_id not in added_nodes:
+            graph.add_node(record.follower_id)
+            added_nodes.append(record.follower_id)
+
+        graph.add_edge(record.user_id, record.follower_id, weight=0.03)
+    pos = nx.spring_layout(graph)
+    nx.set_node_attributes(graph, pos, "pos")
+
+    dump_graph_to_pickle("follower_network", graph)
+
+
+@timeit
+def create_star_network() -> None:
+    con = get_backend_db_con()
+    stargazers_df = con.sql(
+        """
+        select
+            user_name,
+            followers_count,
+            starred_at,
+            retrieved_at,
+            repo_name
+        from int_network_stargazers
+    """
+    ).to_df()
+
+    stargazers = list(StargazerNetworkRecord(*record) for record in stargazers_df.values)
+    repos_with_stargazers = list(set(i.repo_name for i in stargazers))
+
+    print("creating star network...")
+    random.seed(42)
+    added_repos = []
+    current_user = stargazers[0].user_name
+
+    graph = nx.Graph()
+    for repo in repos_with_stargazers:
+        graph.add_node(repo, node_type="repo", repo=repo)
+
+    for record in stargazers:
+        if record.user_name != current_user:
+            added_repos = []
+        node_name = f"{record.user_name}_{record.repo_name}"
+        graph.add_node(
+            node_name,
+            followers_count=record.followers_count,
+            node_type="user_repo",
+            repo=record.repo_name,
+        )
+        graph.add_edge(node_name, record.repo_name, weight=50, edge_type="user_repo")
+        if len(added_repos) > 0:
+            for added_repo in added_repos:
+                graph.add_edge(
+                    node_name,
+                    f"{record.user_name}_{added_repo}",
+                    edge_type="user_user",
+                    weight=0.1,
+                )
+        added_repos.append(record.repo_name)
+        current_user = record.user_name
+
+    pos = nx.spring_layout(graph)
+    nx.set_node_attributes(graph, pos, "pos")
+
+    dump_graph_to_pickle("star_network", graph)

--- a/ampere/dagster/definitions.py
+++ b/ampere/dagster/definitions.py
@@ -3,6 +3,7 @@ from dagster_dbt import DbtCliResource
 
 from .assets import (
     ampere_dbt_assets,
+    bigquery_table_copy,
     dagster_get_commits,
     dagster_get_followers,
     dagster_get_following,
@@ -19,7 +20,9 @@ from .assets import (
     dagster_test_run_fail,
     dagster_test_run_fail2,
     dagster_test_run_pass,
+    github_metrics_table_copy,
 )
+from .jobs import bigquery_daily_job, github_metrics_daily_4_job
 from .project import ampere_project
 from .schedules import schedules
 from .sensors import email_on_run_failure
@@ -40,10 +43,13 @@ defs = Definitions(
         dagster_get_pypi_downloads,
         dagster_refresh_star_network,
         dagster_refresh_follower_network,
+        github_metrics_table_copy,
+        bigquery_table_copy,
         dagster_test_run_fail,
         dagster_test_run_fail2,
         dagster_test_run_pass,
     ],
+    jobs=[github_metrics_daily_4_job, bigquery_daily_job],
     schedules=schedules,
     resources={
         "dbt": DbtCliResource(project_dir=ampere_project),

--- a/ampere/dagster/jobs.py
+++ b/ampere/dagster/jobs.py
@@ -1,0 +1,10 @@
+from dagster import AssetSelection, define_asset_job
+
+github_metrics_daily_4_job = define_asset_job(
+    name="github_metrics_daily_4",
+    selection=AssetSelection.groups("github_metrics_daily_4"),
+)
+
+bigquery_daily_job = define_asset_job(
+    name="bigquery_daily", selection=AssetSelection.groups("bigquery_daily")
+)

--- a/ampere/dagster/schedules.py
+++ b/ampere/dagster/schedules.py
@@ -1,22 +1,18 @@
-from dagster import AssetSelection, DefaultScheduleStatus, ScheduleDefinition
+from dagster import DefaultScheduleStatus, ScheduleDefinition
 
-# split because of 5,000 requests per hour limit
-# https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-authenticated-users
+from .jobs import bigquery_daily_job, github_metrics_daily_4_job
+
 github_metrics_daily_4 = ScheduleDefinition(
     name="github_metrics_daily_4",
-    target=AssetSelection.groups("github_metrics_daily_4"),
+    job=github_metrics_daily_4_job,
     cron_schedule="0 0,6,12,18 * * *",  # every 6 hours, starting at midnight
     default_status=DefaultScheduleStatus.RUNNING,
 )
 
 bigquery_daily = ScheduleDefinition(
     name="bigquery_daily",
-    target=AssetSelection.groups("bigquery_daily"),
+    job=bigquery_daily_job,
     cron_schedule="0 10 * * *",  # daily 10am utc
     default_status=DefaultScheduleStatus.RUNNING,
 )
-schedules = [
-    github_metrics_daily_4,
-    github_metrics_daily_4,
-    bigquery_daily,
-]
+schedules = [github_metrics_daily_4, bigquery_daily]

--- a/ampere/get_pypi_downloads.py
+++ b/ampere/get_pypi_downloads.py
@@ -9,8 +9,8 @@ from google.cloud import bigquery
 from ampere.common import (
     DeltaTableWriteMode,
     DeltaWriteConfig,
+    get_backend_db_con,
     get_current_time,
-    get_db_con,
     get_model_primary_key,
     write_delta_table,
 )
@@ -90,7 +90,7 @@ def refresh_pypi_downloads_from_bigquery(
 def get_pypi_download_query_dates() -> list[PyPIQueryConfig]:
     max_query_days = 45
 
-    con = get_db_con()
+    con = get_backend_db_con()
 
     query_dates = con.sql(
         """
@@ -132,7 +132,7 @@ def get_pypi_download_query_dates() -> list[PyPIQueryConfig]:
 
 
 def get_repos_with_releases() -> list[str]:
-    con = get_db_con()
+    con = get_backend_db_con()
     records = con.sql(
         """
         with

--- a/ampere/get_repo_metrics.py
+++ b/ampere/get_repo_metrics.py
@@ -1,15 +1,11 @@
 import datetime
-import sqlite3
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Callable, Optional
 
 import duckdb
-import pandas as pd
 import requests
-from deltalake import DeltaTable
 
 from ampere.common import (
     DeltaWriteConfig,
@@ -107,6 +103,7 @@ def read_repos(con: duckdb.DuckDBPyConnection) -> list[Repo]:
     repos_dict = con.sql("select * from stg_repos").to_df().to_dict("records")
     repos = [Repo.model_validate(i) for i in repos_dict]
     return repos
+
 
 def get_latest_commit_timestamp(repo: Repo) -> datetime.datetime | None:
     con = get_backend_db_con()

--- a/ampere/get_repo_metrics.py
+++ b/ampere/get_repo_metrics.py
@@ -1,4 +1,5 @@
 import datetime
+import sqlite3
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
@@ -6,15 +7,15 @@ from pathlib import Path
 from typing import Callable, Optional
 
 import duckdb
+import pandas as pd
 import requests
 from deltalake import DeltaTable
 
 from ampere.common import (
     DeltaWriteConfig,
     create_header,
+    get_backend_db_con,
     get_current_time,
-    get_db_con,
-    get_model_foreign_key,
     get_secret,
     timeit,
     write_delta_table,
@@ -102,15 +103,13 @@ def get_task_sleep_seconds(config: TaskSleepConfig) -> float:
     return task_sleep_seconds
 
 
-def read_repos() -> list[Repo]:
-    con = get_db_con()
+def read_repos(con: duckdb.DuckDBPyConnection) -> list[Repo]:
     repos_dict = con.sql("select * from stg_repos").to_df().to_dict("records")
     repos = [Repo.model_validate(i) for i in repos_dict]
     return repos
 
-
 def get_latest_commit_timestamp(repo: Repo) -> datetime.datetime | None:
-    con = get_db_con()
+    con = get_backend_db_con()
     query = f"""
         select max(committed_at)
         from stg_commits 
@@ -136,7 +135,7 @@ def get_org_user_ids() -> list[int]:
     gets unique list of user ids from tracked tables to be added to the `users` table
     if `stg_users` is available, only returns user_ids that have not been refreshed in past `stale_hours` hours
     """
-    con = get_db_con()
+    con = get_backend_db_con()
     stale_hours = 24
     user_ids = (
         con.sql(
@@ -190,7 +189,7 @@ def get_stale_followers_user_ids(endpoint: str) -> list[int]:
     if endpoint not in ["followers", "following"]:
         raise ValueError("expecting one of ['followers', 'following']")
 
-    con = get_db_con()
+    con = get_backend_db_con()
     stale_hours = 24
     if endpoint == "followers":
         query = f"""

--- a/ampere/maintenance.py
+++ b/ampere/maintenance.py
@@ -1,0 +1,55 @@
+import datetime
+import os
+import time
+from pathlib import Path
+
+import duckdb
+
+from ampere.common import get_backend_db_con, get_frontend_db_con
+
+
+def create_new_frontend_db():
+    base_dir = Path(__file__).parents[1] / "data"
+    new_db_dir = base_dir / "frontend_versioned"
+    new_db_dir.mkdir(exist_ok=True)
+
+    today_str = datetime.datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+
+    new_db = new_db_dir / f"frontend_{today_str}.duckdb"
+    symlink_db = base_dir / "frontend.duckdb"
+
+    symlink_db.touch(exist_ok=True)
+
+    os.symlink(new_db, str(symlink_db) + "_tmp")
+    os.rename(str(symlink_db) + "_tmp", symlink_db)
+    print(f"{time.ctime()}: Symlink updated to point to {new_db}")
+
+
+def write_backend_tables_to_frontend() -> None:
+    tables = [
+        "int_network_stargazers",
+        "int_network_follower_details",
+        "stg_repos",
+        "mart_downloads_summary",
+        "mart_feed_events",
+        "mart_issues",
+        "mart_issues_summary",
+        "mart_stargazers_pivoted",
+        "mart_repo_summary",
+    ]
+
+    backend_con = get_backend_db_con()
+    frontend_con = get_frontend_db_con(read_only=False)
+    for table in tables:
+        print(f"writing {table}...")
+        df = backend_con.sql(f"SELECT * FROM {table}").to_df()
+        duckdb.sql(f"CREATE TABLE {table} AS SELECT * FROM df", connection=frontend_con)
+
+
+def copy_backend_to_frontend() -> None:
+    create_new_frontend_db()
+    write_backend_tables_to_frontend()
+
+
+if __name__ == "__main__":
+    copy_backend_to_frontend()

--- a/ampere/models.py
+++ b/ampere/models.py
@@ -164,3 +164,19 @@ class PyPIQueryConfig(SQLModel):
     retrieved_at: datetime.datetime = Field(primary_key=True)
     min_date: str
     max_date: Optional[str]
+
+
+# viz model dataclases
+@dataclass(slots=True, frozen=True)
+class StargazerNetworkRecord:
+    user_name: str
+    followers_count: int
+    starred_at: datetime.datetime
+    retrieved_at: datetime.datetime
+    repo_name: str
+
+
+@dataclass(slots=True, frozen=True)
+class Followers:
+    user_id: str
+    follower_id: int

--- a/ampere/pages/feed.py
+++ b/ampere/pages/feed.py
@@ -5,16 +5,16 @@ import dash_bootstrap_components as dbc
 import pandas as pd
 from dash import Input, Output, callback, dash_table, html
 
-from ampere.common import get_db_con
+from ampere.common import get_frontend_db_con
 from ampere.styling import AmpereDTStyle
 
 dash.register_page(__name__, name="feed", top_nav=True, order=3)
 
 
 def create_feed_table() -> pd.DataFrame:
-    con = get_db_con()
-    return con.sql(
-        """    
+    with get_frontend_db_con() as con:
+        df = con.sql(
+            """    
         select
             strftime(event_timestamp, '%Y-%m-%d')                                   as "date",
             strftime(event_timestamp, '%H:%M')                                      as "time",
@@ -27,8 +27,9 @@ def create_feed_table() -> pd.DataFrame:
             event_link
         from main.mart_feed_events
         order by "date" desc, "time" desc
-        """
-    ).to_df()
+        """,
+        ).to_df()
+    return df
 
 
 @callback(

--- a/ampere/pages/issues.py
+++ b/ampere/pages/issues.py
@@ -5,7 +5,7 @@ import dash_bootstrap_components as dbc
 import pandas as pd
 from dash import Input, Output, callback, dash_table, html
 
-from ampere.common import get_db_con
+from ampere.common import get_frontend_db_con
 from ampere.styling import (
     AmpereDTStyle,
     ColumnInfo,
@@ -17,9 +17,9 @@ dash.register_page(__name__, name="feed", top_nav=True, order=3)
 
 
 def create_issues_table() -> pd.DataFrame:
-    con = get_db_con()
-    return con.sql(
-        """
+    with get_frontend_db_con() as con:
+        df = con.sql(
+            """
        select
            repo,
            author,
@@ -30,14 +30,15 @@ def create_issues_table() -> pd.DataFrame:
            "comments"
        from mart_issues
        order by repo, "days old"
-        """
-    ).to_df()
+        """,
+        ).to_df()
+    return df
 
 
 def create_issues_summary_table() -> pd.DataFrame:
-    con = get_db_con()
-    return con.sql(
-        """
+    with get_frontend_db_con() as con:
+        df = con.sql(
+            """
         select repo,
             "open issues",
             "median issue age (days)",
@@ -46,7 +47,8 @@ def create_issues_summary_table() -> pd.DataFrame:
         from mart_issues_summary
         order by "open issues" desc
         """
-    ).to_df()
+        ).to_df()
+    return df
 
 
 @callback(

--- a/ampere/pages/network_followers.py
+++ b/ampere/pages/network_followers.py
@@ -4,7 +4,7 @@ import pandas as pd
 from dash import Input, Output, callback, dash_table, dcc, html
 from plotly.graph_objects import Figure
 
-from ampere.common import get_db_con
+from ampere.common import get_frontend_db_con
 from ampere.styling import AmpereDTStyle
 from ampere.viz import viz_follower_network
 
@@ -12,9 +12,9 @@ dash.register_page(__name__)
 
 
 def create_followers_table() -> pd.DataFrame:
-    con = get_db_con()
-    df = con.sql(
-        """
+    with get_frontend_db_con() as con:
+        df = con.sql(
+            """
         select
             concat('[', user_name, ']', '(https://www.github.com/', user_name, ')') as user_name,
             full_name                                                               as name,
@@ -27,7 +27,7 @@ def create_followers_table() -> pd.DataFrame:
         from int_network_follower_details
         order by followers_count desc
         """
-    ).to_df()
+        ).to_df()
     return df
 
 

--- a/ampere/pages/network_stargazers.py
+++ b/ampere/pages/network_stargazers.py
@@ -4,7 +4,7 @@ import pandas as pd
 from dash import Input, Output, callback, dash_table, dcc, html
 from plotly.graph_objects import Figure
 
-from ampere.common import get_db_con
+from ampere.common import get_frontend_db_con
 from ampere.styling import AmpereDTStyle
 from ampere.viz import viz_star_network
 
@@ -12,15 +12,16 @@ dash.register_page(__name__, name="network", top_nav=True, order=1)
 
 
 def create_stargazers_table() -> pd.DataFrame:
-    con = get_db_con()
-    # select * because columns are dynamically generated
-    return con.sql(
-        """
+    with get_frontend_db_con() as con:
+        # select * because columns are dynamically generated
+        df = con.sql(
+            """
         select *
         from mart_stargazers_pivoted
         order by followers desc
-        """
-    ).to_df()
+        """,
+        ).to_df()
+    return df
 
 
 @callback(

--- a/ampere/pages/summary.py
+++ b/ampere/pages/summary.py
@@ -8,7 +8,7 @@ import pytz
 from dash import Input, Output, callback, dcc, html
 from plotly.graph_objs import Figure
 
-from ampere.common import get_db_con
+from ampere.common import get_frontend_db_con
 from ampere.styling import AmperePalette, ScreenWidth
 from ampere.viz import viz_summary
 
@@ -86,19 +86,19 @@ def get_summary_date_ranges(
 
 
 def get_summary_data() -> list[dict[Any, Any]]:
-    con = get_db_con()
-    df = con.sql(
-        """
-    select
-        repo_id,
-        metric_type,
-        metric_date,
-        metric_count,
-        repo_name
-    from main.mart_repo_summary
-    order by metric_date
-    """
-    ).to_df()
+    with get_frontend_db_con() as con:
+        df = con.sql(
+            """
+        select
+            repo_id,
+            metric_type,
+            metric_date,
+            metric_count,
+            repo_name
+        from main.mart_repo_summary
+        order by metric_date
+    """,
+        ).to_df()
 
     return df.to_dict("records")
 

--- a/ampere/viz.py
+++ b/ampere/viz.py
@@ -1,6 +1,4 @@
-import datetime
 import pickle
-import random
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional

--- a/ampere/viz.py
+++ b/ampere/viz.py
@@ -12,24 +12,10 @@ import plotly.graph_objects as go
 import pypalettes
 from plotly.graph_objs import Figure
 
-from ampere.common import get_db_con, timeit
+from ampere.common import get_frontend_db_con, timeit
 from ampere.get_repo_metrics import read_repos
+from ampere.models import Followers, StargazerNetworkRecord
 from ampere.styling import AmperePalette, ScreenWidth
-
-
-@dataclass(slots=True, frozen=True)
-class StargazerNetworkRecord:
-    user_name: str
-    followers_count: int
-    starred_at: datetime.datetime
-    retrieved_at: datetime.datetime
-    repo_name: str
-
-
-@dataclass(slots=True, frozen=True)
-class Followers:
-    user_id: str
-    follower_id: int
 
 
 @dataclass(slots=True, frozen=True)
@@ -46,8 +32,15 @@ class FollowerDetails:
     internal_following_pct: float
 
 
+@timeit
 def generate_repo_palette() -> dict[str, str]:
-    repos = sorted(read_repos(), key=lambda x: x.stargazers_count, reverse=True)
+    with get_frontend_db_con() as con:
+        repos = sorted(
+            read_repos(con),
+            key=lambda x: x.stargazers_count,
+            reverse=True,
+        )
+
     n_colors = 10
     n_repos = len(repos)
     repeats = (n_repos // n_colors) + 1
@@ -62,78 +55,6 @@ def generate_repo_palette() -> dict[str, str]:
         output[repo.repo_name] = f"rgb({rgb_string})"
 
     return output
-
-
-@timeit
-def create_star_network(
-    repos: list[str], stargazers: list[StargazerNetworkRecord], out_dir: Path
-) -> nx.Graph:
-    print("creating star network...")
-    random.seed(42)
-    added_repos = []
-    current_user = stargazers[0].user_name
-
-    graph = nx.Graph()
-    for repo in repos:
-        graph.add_node(repo, node_type="repo", repo=repo)
-
-    for record in stargazers:
-        if record.user_name != current_user:
-            added_repos = []
-        node_name = f"{record.user_name}_{record.repo_name}"
-        graph.add_node(
-            node_name,
-            followers_count=record.followers_count,
-            node_type="user_repo",
-            repo=record.repo_name,
-        )
-        graph.add_edge(node_name, record.repo_name, weight=50, edge_type="user_repo")
-        if len(added_repos) > 0:
-            for added_repo in added_repos:
-                graph.add_edge(
-                    node_name,
-                    f"{record.user_name}_{added_repo}",
-                    edge_type="user_user",
-                    weight=0.1,
-                )
-        added_repos.append(record.repo_name)
-        current_user = record.user_name
-
-    pos = nx.spring_layout(graph)
-    nx.set_node_attributes(graph, pos, "pos")
-
-    out_dir.mkdir(exist_ok=True, parents=True)
-    out_path = out_dir / "star_network.pkl"
-    with out_path.open("wb") as f:
-        pickle.dump(graph, f)
-
-    return graph
-
-
-@timeit
-def create_follower_network(follower_info: list[Followers], out_dir: Path) -> nx.Graph:
-    random.seed(42)
-    added_nodes = []
-    graph = nx.Graph()
-    for record in follower_info:
-        if record.user_id not in added_nodes:
-            graph.add_node(record.user_id)
-            added_nodes.append(record.user_id)
-
-        if record.follower_id not in added_nodes:
-            graph.add_node(record.follower_id)
-            added_nodes.append(record.follower_id)
-
-        graph.add_edge(record.user_id, record.follower_id, weight=0.03)
-    pos = nx.spring_layout(graph)
-    nx.set_node_attributes(graph, pos, "pos")
-
-    out_dir.mkdir(exist_ok=True, parents=True)
-    out_path = out_dir / "follower_network.pkl"
-    with out_path.open("wb") as f:
-        pickle.dump(graph, f)
-
-    return graph
 
 
 @timeit
@@ -198,6 +119,7 @@ def create_star_network_plot(
     node_df["size_group"] = pd.qcut(node_df["size"], 6, labels=False, duplicates="drop")
     node_df["size_group"] = (node_df["size_group"] + 1) * 5
 
+    repo_palette = generate_repo_palette()
     all_node_traces = []
     for repo in repos:
         repo_df = node_df.query(f"repo == '{repo}'")
@@ -205,7 +127,7 @@ def create_star_network_plot(
             x=repo_df.x,
             y=repo_df.y,
             marker_size=repo_df.size_group,
-            marker_color=REPO_PALETTE[repo],
+            marker_color=repo_palette[repo],
             mode="markers",
             hoverinfo="text",
             hovertext=repo_df.text,
@@ -344,35 +266,35 @@ def create_follower_network_plot(
     return fig
 
 
+def read_network_graph_pickle(pkl_name: str) -> nx.Graph:
+    out_dir = Path(__file__).parents[1] / "data" / "viz"
+    out_path = out_dir / f"{pkl_name}.pkl"
+    with out_path.open("rb") as f:
+        network = pickle.load(f)
+    return network
+
+
 @timeit
 def viz_star_network(use_cache: bool = True, show_fig: bool = False) -> Figure:
-    con = get_db_con()
-    stargazers = con.sql(
-        """
+    with get_frontend_db_con() as con:
+        stargazers = con.sql(
+            """
         select
             user_name,
             followers_count,
             starred_at,
             retrieved_at,
             repo_name
-        from int_network_stargazers
-    """
-    ).to_df()
+        from int_network_stargazers,
+    """,
+        ).to_df()
 
     stargazers = list(StargazerNetworkRecord(*record) for record in stargazers.values)
     repos_with_stargazers = list(set(i.repo_name for i in stargazers))
-    repos = [i for i in REPO_PALETTE if i in repos_with_stargazers]
-    out_dir = Path(__file__).parents[1] / "data" / "viz"
-    out_path = out_dir / "star_network.pkl"
+    repo_palette = generate_repo_palette()
+    repos = [i for i in repo_palette if i in repos_with_stargazers]
 
-    if use_cache and out_path.exists():
-        print("loading from cache")
-        with out_path.open("rb") as f:
-            network = pickle.load(f)
-    else:
-        print("creating from scratch")
-        network = create_star_network(repos, stargazers, out_dir)
-
+    network = read_network_graph_pickle("star_network")
     fig = create_star_network_plot(network, repos, stargazers)
     if show_fig:
         fig.show()
@@ -381,18 +303,17 @@ def viz_star_network(use_cache: bool = True, show_fig: bool = False) -> Figure:
 
 
 @timeit
-def viz_follower_network(use_cache: bool = True, show_fig: bool = False) -> Figure:
-    con = get_db_con()
-    followers = (
-        con.sql("select user_id, follower_id from int_internal_followers")
-        .to_df()
-        .to_dict(orient="records")
-    )
-    followers = list(Followers(**record) for record in followers)  # type: ignore
+def viz_follower_network(show_fig: bool = False) -> Figure:
+    with get_frontend_db_con() as con:
+        followers = (
+            con.sql("select user_id, follower_id from int_internal_followers")
+            .to_df()
+            .to_dict(orient="records")
+        )
 
-    follower_details_dict = (
-        con.sql(
-            """
+        follower_details_dict = (
+            con.sql(
+                """
         select
         user_id,
         user_name,
@@ -405,22 +326,18 @@ def viz_follower_network(use_cache: bool = True, show_fig: bool = False) -> Figu
         internal_followers_pct,
         internal_following_pct
         from int_network_follower_details
-        """
+        """,
+            )
+            .to_df()
+            .to_dict(orient="records")
         )
-        .to_df()
-        .to_dict(orient="records")
-    )
+
+    followers = [Followers(**record) for record in followers]  # type: ignore
     follower_details_dc = [FollowerDetails(**i) for i in follower_details_dict]  # type: ignore
     follower_details = {i.user_id: i for i in follower_details_dc}
 
-    out_dir = Path(__file__).parents[1] / "data" / "viz"
-    out_path = out_dir / "follower_network.pkl"
-    if use_cache and out_path.exists():
-        with out_path.open("rb") as f:
-            network = pickle.load(f)
-    else:
-        print("creating follower network...")
-        network = create_follower_network(followers, out_dir)
+    # reads precomputed network graph from scheduled job
+    network = read_network_graph_pickle("follower_network")
 
     print("creating plot..")
     fig = create_follower_network_plot(network, followers, follower_details)
@@ -462,6 +379,7 @@ def viz_summary(
             "pull requests",
         ]
 
+    repo_palette = generate_repo_palette()
     fig = px.line(
         df,
         x="metric_date",
@@ -472,13 +390,13 @@ def viz_summary(
         template="simple_white",
         hover_name="repo_name",
         markers=True,
-        color_discrete_map=REPO_PALETTE,
+        color_discrete_map=repo_palette,
         height=550 * 6 // facet_col_wrap,
         facet_col_spacing=0.08,
         facet_row_spacing=facet_row_spacing,
         category_orders={
             "metric_type": metric_type_order,
-            "repo_name": REPO_PALETTE.keys(),
+            "repo_name": repo_palette.keys(),
         },
     )
 
@@ -544,8 +462,6 @@ def viz_summary(
 
     return fig
 
-
-REPO_PALETTE = generate_repo_palette()
 
 NETWORK_LAYOUT = go.Layout(
     showlegend=True,

--- a/scripts/backfill_pypi_downloads.py
+++ b/scripts/backfill_pypi_downloads.py
@@ -3,7 +3,7 @@ from typing import Annotated, Optional
 
 import typer
 
-from ampere.common import get_db_con
+from ampere.common import get_backend_db_con
 from ampere.get_pypi_downloads import add_backfill_to_table
 
 app = typer.Typer()
@@ -28,7 +28,7 @@ def backfill(
             tzinfo=datetime.timezone.utc
         )
     else:
-        con = get_db_con()
+        con = get_backend_db_con()
         min_date_dt = con.sql(
             f"select created_at from stg_repos where repo_name = '{repo_dependency}'"
         ).fetchall()[0][0]


### PR DESCRIPTION
duckdb requires an exclusive lock to write table data. These changes create a slim frontend_{timestamp}.duckdb file at the end of every scheduled run and update a symlink pointing to the latest version to be accessed by the dashboard. The frontend is strictly accessed by read-only operations to allow concurrent requests